### PR TITLE
#7: Add command-line arguments to dotnet build and test.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,14 +18,16 @@ jobs:
         DOTNET_NOLOGO: true
       id: BE
     - name: '.NET Restore'
-      run: dotnet restore --verbosity normal
+      run: dotnet restore --verbosity minimal
       working-directory: Source
     - name: '.NET Build'
-      run: dotnet build --no-restore --verbosity normal
+      run: dotnet build --no-restore --verbosity minimal
       working-directory: Source
     - name: '.NET Test'
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity minimal
       working-directory: Source
     - name: 'Version Info'
       run: echo '.NET version ${{ steps.BE.outputs.dotnet-version }}'
+    - name: 'OS Info'
+      run: echo 'OS ${{ vars.UBUNTU_VERSION }}'
       

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    types: [ready_for_review, synchronize, opened, reopened]
 
 jobs:
   BE:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,10 +21,10 @@ jobs:
       run: dotnet restore
       working-directory: Source
     - name: '.NET Build'
-      run: dotnet build
+      run: dotnet build --no-restore --verbosity diagnostic
       working-directory: Source
     - name: '.NET Test'
-      run: dotnet test
+      run: dotnet test --no-restore --verbosity diagnostic
       working-directory: Source
     - name: 'Version Info'
       run: echo '.NET version ${{ steps.BE.outputs.dotnet-version }}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,13 +18,13 @@ jobs:
         DOTNET_NOLOGO: true
       id: BE
     - name: '.NET Restore'
-      run: dotnet restore
+      run: dotnet restore --verbosity normal
       working-directory: Source
     - name: '.NET Build'
-      run: dotnet build --no-restore --verbosity diagnostic
+      run: dotnet build --no-restore --verbosity normal
       working-directory: Source
     - name: '.NET Test'
-      run: dotnet test --no-restore --verbosity diagnostic
+      run: dotnet test --no-restore --verbosity normal
       working-directory: Source
     - name: 'Version Info'
       run: echo '.NET version ${{ steps.BE.outputs.dotnet-version }}'


### PR DESCRIPTION
Updates verbosity level of `dotnet` commands and creates a new step that prints the OS version of the runner.