### PR TITLE
Fix README PR Checks Badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-### Production
-[![PR Checks](https://github.com/AnthonyMonterrosa/C-sharp-service-stack/actions/workflows/checks.yml/badge.svg?branch=production)](https://github.com/AnthonyMonterrosa/C-sharp-service-stack/actions/workflows/checks.yml)
-
 ### Main
-[![PR Checks](https://github.com/AnthonyMonterrosa/C-sharp-service-stack/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/AnthonyMonterrosa/C-sharp-service-stack/actions/workflows/checks.yml)
+[![PR Checks](https://github.com/AnthonyMonterrosa/C-sharp-service-stack/actions/workflows/checks.yml/badge.svg)](https://github.com/AnthonyMonterrosa/C-sharp-service-stack/actions/workflows/checks.yml)
 
 # C-sharp-service-stack
 This repository is my practice sandbox for creating a C# application from the bottom to the top. This includes:


### PR DESCRIPTION
The badges are broken now because of how they're filtered. `PR Checks` are triggered on `pull_request` by feature branches. So, I am switching the badges to default right now, no filtering by branch or event. In the future it may be fixable by changing `PR Checks` to be triggered by `pull_request_target: types: [main, test, production]` but that's not being changed right now.