### PR TITLE
#28: Fix "Create Docker Image" Workflow

### DIFF
--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -1,0 +1,22 @@
+name: Create Docker Image
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: {{ vars.UBUNTU_VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_PACKAGES_PAT }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Source/API/Website.API/Dockerfile
+          push: true
+          tags: ghcr.io/anthonymonterrosa/c-sharp-service-stack:latest

--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   build:
-    runs-on: {{ vars.UBUNTU_VERSION }}
+    runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_PACKAGES_PAT }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Source/API/Website.API/Dockerfile


### PR DESCRIPTION
There was a syntax error in evaluating the `UBUNTU_VERSION` repository variable, where it was invoked with `{{ vars.UBUNTU_VERSION }}` instead of `${{ vars.UBUNTU_VERSION }}`.

Also, updated versions of `docker/login-action` and `docker/build-push-action` to their latest versions.