### PR TITLE
#28: Update Dockerfile Context

### DIFF
--- a/Source/API/Website.API/Dockerfile
+++ b/Source/API/Website.API/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 
-COPY . .
-RUN ls -la
+COPY ./Source/API/Webiste.API .
 
 # Restore as distinct layers
 RUN dotnet restore


### PR DESCRIPTION
This actually updates the `COPY` command instead of messing with the docker build context.