### PR TITLE
#28: Try to Fix `dotnet restore` Build Context

### DIFF
--- a/Source/API/Website.API/Dockerfile
+++ b/Source/API/Website.API/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 
-COPY . .
+COPY . /Build
+WORKDIR /Build
 
 RUN ls -la
 


### PR DESCRIPTION
I believe before these changes `dotnet restore` was scanning all files and folders in the docker container, since `dotnet restore` was run in `/` (root). Adding a build directory could fix the problem.